### PR TITLE
Use hard-coded 'pathSegmentsToKeep'

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,3 @@
 
 # API KEY for google sheet (It's all right. It's restricted by domain.)
 REACT_APP_API_KEY="AIzaSyA0_136gWrkqUfV5t25yi4rKWQpEpXDl9c"
-
-# for 404 hack (public/404.html)
-REACT_APP_PATH_SEGMENTS_TO_KEEP=0

--- a/.env.local.sample
+++ b/.env.local.sample
@@ -4,7 +4,3 @@
 #   The API key in '.env' only works in 'localhost' and 'hal-to.github.io'.
 #   To publish github-pages from forked repo, you should use your own api key.
 REACT_APP_API_KEY="YOUR_OWN_API_KEY"
-
-# for 404 hack (public/404.html)
-#   It seemst that forked repo should set this value 1.
-REACT_APP_PATH_SEGMENTS_TO_KEEP=1

--- a/public/404.html
+++ b/public/404.html
@@ -22,7 +22,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = Process.env.REACT_APP_PATH_SEGMENTS_TO_KEEP;
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
It seems that '.env' doesn't work for '404.html'